### PR TITLE
Support IIIF Authentication for requesting resources

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+inherit_from: .rubocop_todo.yml
+
 AllCops:
   Exclude:
     - 'Gemfile'
@@ -7,6 +9,7 @@ AllCops:
     - 'spec/spec_helper.rb'
     - 'spec/teaspoon_env.rb'
     - 'vendor/**/*'
+    - 'app/controllers/concerns/action_controller/**/*'
   RunRailsCops: true
 
 Metrics/LineLength:

--- a/app/controllers/concerns/action_controller/http_authentication/bearer.rb
+++ b/app/controllers/concerns/action_controller/http_authentication/bearer.rb
@@ -1,0 +1,190 @@
+module ActionController
+  module HttpAuthentication
+    # Makes it dead easy to do HTTP Bearer authentication.
+    #
+    # Simple Bearer example:
+    #
+    #   class PostsController < ApplicationController
+    #     BEARER_TOKEN = "secret"
+    #
+    #     before_action :authenticate, except: [ :index ]
+    #
+    #     def index
+    #       render plain: "Everyone can see me!"
+    #     end
+    #
+    #     def edit
+    #       render plain: "I'm only accessible if you know the password"
+    #     end
+    #
+    #     private
+    #       def authenticate
+    #         authenticate_or_request_with_http_bearer_token do |token, options|
+    #           token == TOKEN
+    #         end
+    #       end
+    #   end
+    #
+    #
+    # Here is a more advanced Bearer Token example where only Atom feeds and the XML API is protected by HTTP token authentication,
+    # the regular HTML interface is protected by a session approach:
+    #
+    #   class ApplicationController < ActionController::Base
+    #     before_action :set_account, :authenticate
+    #
+    #     protected
+    #       def set_account
+    #         @account = Account.find_by(url_name: request.subdomains.first)
+    #       end
+    #
+    #       def authenticate
+    #         case request.format
+    #         when Mime::XML, Mime::ATOM
+    #           if user = authenticate_with_http_bearer_token { |t, o| @account.users.authenticate(t, o) }
+    #             @current_user = user
+    #           else
+    #             request_http_token_authentication
+    #           end
+    #         else
+    #           if session_authenticated?
+    #             @current_user = @account.users.find(session[:authenticated][:user_id])
+    #           else
+    #             redirect_to(login_url) and return false
+    #           end
+    #         end
+    #       end
+    #   end
+    #
+    #
+    # In your integration tests, you can do something like this:
+    #
+    #   def test_access_granted_from_xml
+    #     get(
+    #       "/notes/1.xml", nil,
+    #       'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Bearer.encode_credentials(users(:dhh).token)
+    #     )
+    #
+    #     assert_equal 200, status
+    #   end
+    #
+    #
+    # On shared hosts, Apache sometimes doesn't pass authentication headers to
+    # FCGI instances. If your environment matches this description and you cannot
+    # authenticate, try this rule in your Apache setup:
+    #
+    #   RewriteRule ^(.*)$ dispatch.fcgi [E=X-HTTP_AUTHORIZATION:%{HTTP:Authorization},QSA,L]
+    module Bearer
+      BEARER_TOKEN_KEY = 'token='
+      BEARER_TOKEN_REGEX = /^Bearer /
+      AUTHN_PAIR_DELIMITERS = /(?:,|;|\t+)/
+      extend self
+
+      module ControllerMethods
+        def authenticate_or_request_with_http_bearer_token(realm = "Application", &login_procedure)
+          authenticate_with_http_bearer_token(&login_procedure) || request_http_bearer_token_authentication(realm)
+        end
+
+        def authenticate_with_http_bearer_token(&login_procedure)
+          Bearer.authenticate(self, &login_procedure)
+        end
+
+        def request_http_bearer_token_authentication(realm = "Application")
+          Bearer.authentication_request(self, realm)
+        end
+      end
+
+      def has_bearer_credentials?(request)
+        request.authorization.present? && (auth_scheme(request) == 'Bearer')
+      end
+
+      # If bearer Authorization header is present, call the login
+      # procedure with the present token and options.
+      #
+      # [controller]
+      #   ActionController::Base instance for the current request.
+      #
+      # [login_procedure]
+      #   Proc to call if a token is present. The Proc should take two arguments:
+      #
+      #     authenticate(controller) { |token, options| ... }
+      #
+      # Returns the return value of <tt>login_procedure</tt> if a
+      # token is found. Returns <tt>nil</tt> if no token is found.
+
+      def authenticate(controller, &login_procedure)
+        token, options = bearer_token_and_options(controller.request)
+        unless token.blank?
+          login_procedure.call(token, options)
+        end
+      end
+
+      # Parses the token and options out of the token authorization header. If
+      # the header looks like this:
+      #   Authorization: Bearer token="abc", nonce="def"
+      # Then the returned token is "abc", and the options is {nonce: "def"}
+      #
+      # request - ActionDispatch::Request instance with the current headers.
+      #
+      # Returns an Array of [String, Hash] if a token is present.
+      # Returns nil if no token is found.
+      def bearer_token_and_options(request)
+        authorization_request = request.authorization.to_s
+        if authorization_request[BEARER_TOKEN_REGEX]
+          params = bearer_token_params_from authorization_request
+          [params.shift[1], Hash[params].with_indifferent_access]
+        end
+      end
+
+      def bearer_token_params_from(auth)
+        rewrite_param_values params_array_from raw_params auth
+      end
+
+      # Takes raw_params and turns it into an array of parameters
+      def params_array_from(raw_params)
+        raw_params.map { |param| param.split %r/=(.+)?/ }
+      end
+
+      # This removes the <tt>"</tt> characters wrapping the value.
+      def rewrite_param_values(array_params)
+        array_params.each { |param| (param[1] || "").gsub! %r/^"|"$/, '' }
+      end
+
+      # This method takes an authorization body and splits up the key-value
+      # pairs by the standardized <tt>:</tt>, <tt>;</tt>, or <tt>\t</tt>
+      # delimiters defined in +AUTHN_PAIR_DELIMITERS+.
+      def raw_params(auth)
+        _raw_params = auth.sub(BEARER_TOKEN_REGEX, '').split(/\s*#{AUTHN_PAIR_DELIMITERS}\s*/)
+
+        if !(_raw_params.first =~ %r{\A#{BEARER_TOKEN_KEY}})
+          _raw_params[0] = "#{BEARER_TOKEN_KEY}#{_raw_params.first}"
+        end
+
+        _raw_params
+      end
+
+      # Encodes the given token and options into an Authorization header value.
+      #
+      # token   - String token.
+      # options - optional Hash of the options.
+      #
+      # Returns String.
+      def encode_credentials(token, options = {})
+        values = ["#{BEARER_TOKEN_KEY}#{token.to_s.inspect}"] + options.map do |key, value|
+          "#{key}=#{value.to_s.inspect}"
+        end
+        "Bearer #{values * ", "}"
+      end
+
+      # Sets a WWW-Authenticate to let the client know a token is desired.
+      #
+      # controller - ActionController::Base instance for the outgoing response.
+      # realm      - String realm to use in the header.
+      #
+      # Returns nothing.
+      def authentication_request(controller, realm)
+        controller.headers["WWW-Authenticate"] = %(Bearer realm="#{realm.gsub(/"/, "")}")
+        controller.__send__ :render, :text => "HTTP Bearer Token: Access denied.\n", :status => :unauthorized
+      end
+    end
+  end
+end

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -1,18 +1,18 @@
 ##
 # API for delivering IIIF-compatible images and image tiles
 class IiifController < ApplicationController
-  before_action :load_image, except: [:token]
-  before_action :add_iiif_profile_header, except: [:token]
+  before_action :load_image
+  before_action :add_iiif_profile_header
 
   rescue_from ActionController::MissingFile do
     render text: 'File not found', status: :not_found
   end
 
-  before_action only: :show do
+  before_action except: :metadata do
     fail ActionController::MissingFile, 'File Not Found' unless @image.valid?
   end
 
-  before_action only: :meadata do
+  before_action only: :metadata do
     fail ActionController::MissingFile, 'File Not Found' unless @image.exist?
   end
 
@@ -36,20 +36,6 @@ class IiifController < ApplicationController
 
     self.content_type = 'application/json'
     self.response_body = JSON.pretty_generate(image_info)
-  end
-
-  def token
-    respond_to do |format|
-      format.json do
-        response = if current_user
-                     { accessToken: current_user.token, tokenType: 'Bearer', expiresIn: 3600 }
-                   else
-                     { error: 'missingCredentials', description: '' }
-                   end
-
-        render json: response.to_json, callback: params[:callback], status: current_user.present? ? :ok : :unauthorized
-      end
-    end
   end
 
   private

--- a/app/controllers/iiif_token_controller.rb
+++ b/app/controllers/iiif_token_controller.rb
@@ -1,0 +1,51 @@
+# API to create IIIF Authentication access tokens
+class IiifTokenController < ApplicationController
+  # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
+  def create
+    token = mint_bearer_token if current_user
+
+    write_bearer_token_cookie(token) if token
+
+    respond_to do |format|
+      format.html { redirect_to format: 'json' }
+      format.json do
+        response = if token
+                     {
+                       accessToken: token,
+                       tokenType: 'Bearer',
+                       expiresIn: 3600
+                     }
+                   else
+                     { error: 'missingCredentials', description: '' }
+                   end
+
+        status = if request.xhr? || token
+                   :ok
+                 else
+                   :unauthorized
+                 end
+
+        render json: response.to_json, callback: params[:callback], status: status
+      end
+    end
+  end
+  # rubocop:enable Metrics/MethodLength, Metrics/PerceivedComplexity
+
+  private
+
+  def mint_bearer_token
+    encode_credentials(current_user.token).sub('Bearer ', '')
+  end
+
+  def write_bearer_token_cookie(token)
+    # webauth users already have a webauth cookie; no additional cookie needed
+    return if current_user.webauth_user?
+
+    cookies[:bearer_token] = {
+      value: token,
+      expires: 1.hour.from_now,
+      httponly: true,
+      secure: request.ssl?
+    }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,26 +3,39 @@
 class User
   include ActiveModel::Model
 
-  attr_accessor :id, :webauth_user, :app_user, :ldap_groups
+  attr_accessor :id, :webauth_user, :app_user, :token_user, :ldap_groups
 
   def webauth_user?
     webauth_user
   end
 
   def stanford?
-    webauth_user? && (ldap_groups & Settings.user.stanford_groups).any?
+    ldap_groups.present? && (ldap_groups & Settings.user.stanford_groups).any?
   end
 
   def app_user?
     app_user
   end
 
+  def token_user?
+    token_user
+  end
+
   def etag
     id
   end
 
+  def self.from_token(token, _options = {})
+    attributes, timestamp = encryptor.decrypt_and_verify(token)
+
+    User.new(attributes.merge(token_user: true)) if timestamp >= 1.hour.ago
+  end
+
   def token
-    crypt = ActiveSupport::MessageEncryptor.new(Rails.application.secrets.secret_key_base)
-    crypt.encrypt_and_sign(etag)
+    self.class.encryptor.encrypt_and_sign([{ id: id, ldap_groups: ldap_groups }, Time.zone.now])
+  end
+
+  def self.encryptor
+    ActiveSupport::MessageEncryptor.new(Rails.application.secrets.secret_key_base)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   root 'stacks#index'
 
   get '/auth/iiif' => 'webauth#login', as: :iiif_auth_api
-  get '/image/iiif/token' => 'iiif#token', as: :iiif_token_api
+  get '/image/iiif/token' => 'iiif_token#create', as: :iiif_token_api
 
   constraints identifier: %r{[^/]+}, size: %r{[^/]+} do
     get '/image/iiif/:identifier' => 'iiif#show', as: :iiif_base

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -17,6 +17,21 @@ describe ApplicationController do
       end
     end
 
+    context 'with a Bearer token' do
+      let(:user) { User.new(id: 'test-user', ldap_groups: ['stanford:stanford']) }
+      let(:credentials) { ActionController::HttpAuthentication::Bearer.encode_credentials(user.token) }
+
+      before do
+        request.env['HTTP_AUTHORIZATION'] = credentials
+      end
+
+      it 'supports bearer auth users' do
+        expect(subject.id).to eq 'test-user'
+        expect(subject).to be_a_token_user
+        expect(subject).to be_stanford
+      end
+    end
+
     context 'with a REMOTE_USER header' do
       before do
         request.env['REMOTE_USER'] = 'my-user'

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -81,38 +81,4 @@ describe IiifController, :vcr do
       expect(info['tiles'].first).to include 'width' => 1024, 'height' => 1024
     end
   end
-
-  describe '#token' do
-    subject do
-      get :token, format: :json
-    end
-
-    before do
-      allow(controller).to receive(:current_user).and_return(user)
-    end
-
-    context 'with a user' do
-      let(:user) { User.new }
-
-      it 'returns the token response' do
-        expect(subject.status).to eq 200
-
-        data = JSON.parse(subject.body)
-        expect(data['accessToken']).not_to be_blank
-        expect(data['tokenType']).to eq 'Bearer'
-        expect(data['expiresIn']).to be > 0
-      end
-    end
-
-    context 'without a user' do
-      let(:user) { nil }
-
-      it 'returns the error response' do
-        expect(subject.status).to eq 401
-
-        data = JSON.parse(subject.body)
-        expect(data['error']).to eq 'missingCredentials'
-      end
-    end
-  end
 end

--- a/spec/controllers/iiif_token_controller_spec.rb
+++ b/spec/controllers/iiif_token_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe IiifTokenController do
+  describe '#create' do
+    subject do
+      get :create, format: :json
+    end
+
+    let(:user) { nil }
+
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+    end
+
+    context 'HTML format' do
+      subject do
+        get :create, format: :html
+      end
+
+      it 'redirects to JSON' do
+        expect(subject).to redirect_to format: :json
+      end
+    end
+
+    context 'with a user' do
+      let(:user) { User.new id: 'xyz' }
+
+      it 'returns the token response' do
+        expect(subject.status).to eq 200
+
+        data = JSON.parse(subject.body)
+        expect(data['accessToken']).not_to be_blank
+        expect(data['tokenType']).to eq 'Bearer'
+        expect(data['expiresIn']).to be > 0
+      end
+    end
+
+    context 'without a user' do
+      it 'returns the error response' do
+        expect(subject.status).to eq 401
+
+        data = JSON.parse(subject.body)
+        expect(data['error']).to eq 'missingCredentials'
+      end
+    end
+  end
+end

--- a/spec/features/iiif_spec.rb
+++ b/spec/features/iiif_spec.rb
@@ -1,4 +1,38 @@
 require 'rails_helper'
 
 describe 'IIIF integration tests' do
+  it 'can present bearer tokens for a valid user session' do
+    # get the token as a webauth user
+    allow_any_instance_of(ActionDispatch::Request).to receive(:remote_user).and_return('xyz')
+
+    visit '/image/iiif/token.json'
+    data = JSON.parse(page.body)
+
+    expect(data).to include 'accessToken'
+
+    # regenerate the token as a token-based user
+    allow_any_instance_of(ActionDispatch::Request).to receive(:remote_user).and_return(nil)
+    page.driver.header 'Authorization', "Bearer #{data['accessToken']}"
+
+    visit '/image/iiif/token.json'
+    data = JSON.parse(page.body)
+
+    expect(page.driver.response.headers).to include 'Set-Cookie'
+
+    expect(data).to include 'accessToken'
+
+    # and, finally, try the request with cookie-based authentication
+    page.driver.header 'Authorization', nil
+
+    visit '/image/iiif/token.json'
+
+    data = JSON.parse(page.body)
+
+    expect(data).to include 'accessToken'
+
+    # and make sure it contains the information we think it should
+    u = User.from_token(data['accessToken'].sub('token="', '').sub('"', ''))
+
+    expect(u.id).to eq 'xyz'
+  end
 end


### PR DESCRIPTION
In f8125401e808b5d0090972692dae42af4424ce60, we added support for generating IIIF Authentication tokens, but were still relying on the login service to maintain a WebAuthed session. b2c8dbb finishes that work by supporting Bearer token authentication in addition to WebAuth + Basic Auth.  