### PR TITLE
Provide scaleFactors that are powers of 2

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -68,7 +68,7 @@ class IiifController < ApplicationController
     @image ||= StacksImage.new(image_params)
   end
 
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def image_info
     info = @image.info do |md|
       if can? :download, @image
@@ -81,6 +81,9 @@ class IiifController < ApplicationController
     end
 
     info['sizes'] = [{ width: 400, height: 400 }] unless @image.maybe_downloadable?
+
+    info['tiles'][0]['scaleFactors'] = info['tiles'][0]['scaleFactors']
+                                       .map { |x| 2**(x - 1) }
 
     info['service'] = {
       '@id' => iiif_auth_api_url,
@@ -96,7 +99,7 @@ class IiifController < ApplicationController
 
     info
   end
-  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   def image_params
     params.slice(:region, :size, :rotation, :quality, :format).merge(identifier_params).merge(canonical_params)

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -80,5 +80,12 @@ describe IiifController, :vcr do
       info = JSON.parse(controller.response_body.first)
       expect(info['tiles'].first).to include 'width' => 1024, 'height' => 1024
     end
+
+    it 'includes scaleFactors that are power of 2' do
+      allow(controller).to receive(:can?).and_return(true)
+      subject
+      info = JSON.parse(controller.response_body.first)
+      expect(info['tiles'][0]['scaleFactors']).to match_array [1, 2, 4, 8, 16]
+    end
   end
 end


### PR DESCRIPTION
Closes #14 . Should also help with https://github.com/sul-dlss/sul-embed/issues/484 , by providing a more performant tileresponse

I'm a bit weary though, this doesn't feel like the right way to do this. Should we be changing the calculation here:

https://github.com/jronallo/djatoka/blob/e8d4f77311c47563da35f46a79c2508cc215593f/lib/djatoka/metadata.rb#L60-L77

or here:

https://github.com/jronallo/djatoka/blob/e8d4f77311c47563da35f46a79c2508cc215593f/lib/djatoka/metadata.rb#L159-L161

Do the `scaleFactors` correspond to the calculated sizes at those levels?