### PR TITLE
add FIXME comment to stacks_file model's valid method

### DIFF
--- a/app/models/stacks_file.rb
+++ b/app/models/stacks_file.rb
@@ -16,6 +16,8 @@ class StacksFile
   end
 
   def valid?
+    # FIXME: image_exist? is defined in app/models/concerns/djatoka_adapter.rb,
+    #  which is included in StacksImage, but is probably undefined here
     image_exist?
   end
 


### PR DESCRIPTION
b/c it's too scary to mess with a method called "valid" in a model -- too much rails magic may be at work.  Probably the fix is to change it to file_exist?  but I am feeling wimpy.