### PR TITLE
Media stream token management

### DIFF
--- a/app/models/stacks_media_token.rb
+++ b/app/models/stacks_media_token.rb
@@ -1,0 +1,122 @@
+# need resolv for the IP address regex
+require 'resolv'
+
+# this class is used for representing a time-limited grant of authorization to
+# view a streaming resource.  the token object has fields representing the resource
+# (id, file_name) and the request origin (user_ip_addr). additionally,
+# it has a timestamp indicating when it was created.
+#
+# the object can be serialized as a signed/encrypted string representation of
+# itself.  the class can also create an instance of itself from such a representation.
+#
+# the class can also take an arbitrary string and a list of expected values for the
+# token's fields.  if the string can be decrypted successfully (proving stacks
+# minted it), the recovered hash can be checked against the provided list of values
+# and the current time.  if the expected values match the decrypted values and the
+# token is younger than the max age, it's good, otherwise, it's not.
+#
+# thus, stacks can mint a token string and give it to a user, who can give it
+# to a service that stacks trusts, to allow that service to fulfil a request
+# to stream a resource.
+#
+# the order of operations might be something like the following example:
+# * a user makes a request to a stacks URL for a streaming resource.
+# * stacks creates a StacksMediaToken and serializes it to its encrypted string form.
+# * the encrypted string form of the token is included as part of a redirect to wowza.
+# * wowza receives the request for the resource stream, with the encrypted string.
+# * wowza calls back to stacks, and passes along: encrypted token string, IP from which
+#   it received the request, id, and file name.
+# * stacks uses StacksMediaToken#verify_encrypted_token? to determine whether
+#   the encrypted string represents a still-valid token for the given resource.
+# * if it does, it returns 200 OK to wowza, if it doesn't then it returns 403 Forbidden.
+# * wowza serves the stream or not based on the response it gets from stacks.
+# * this checking in wowza can be implemented via a wowza request processing plugin.
+#
+# notes:
+# * there's no check for whether a token's been used (there's no record of the token having been
+#   created in memory or DB, and so nothing to mark).  but that might be a good additional check.
+# * encrypted token verfication assumes that an attacker cannot create a valid encrypted token string
+#   without having compromised the stacks server, since the secret_key_base is needed to create a valid
+#   encrypted token string.  also, the usual caveats about trusting the math, and Rails' implementation
+#   of it, and our use of their implementation.
+class StacksMediaToken
+  include ActiveModel::Validations
+
+  validates! :id, presence: true, format: /\A(druid:)?([a-z]{2})(\d{3})([a-z]{2})(\d{4})\z/i
+  validates! :file_name, presence: true
+  validates! :user_ip_addr, presence: true, format: Resolv::AddressRegex
+
+  attr_reader :id, :file_name, :user_ip_addr, :timestamp
+
+  def self.max_token_age
+    Settings.stream.max_token_age.to_i.seconds
+  end
+
+  def initialize(id, file_name, user_ip_addr)
+    @id = id
+    @file_name = file_name
+    @user_ip_addr = user_ip_addr
+    @timestamp = Time.zone.now
+    validate
+  end
+
+  def to_hash
+    {
+      id: id,
+      file_name: file_name,
+      user_ip_addr: user_ip_addr,
+      timestamp: timestamp
+    }
+  end
+
+  # though the object is instantiated by the constructor, the string returned by this
+  # method is what "mints" the token for the purposes of checks from other services
+  def to_encrypted_string
+    self.class.send(:encryptor).encrypt_and_sign to_hash
+  end
+
+  # this is how a string is checked to confirm whether it represents a still-valid token minted by stacks
+  # NOTE: since this method does an expiry check at the time it's run, its result can
+  # become stale, and should not be cached.
+  def self.verify_encrypted_token?(encrypted_string, expected_id, expected_file_name, expected_user_ip_addr)
+    # if it can be decrypted, we assume we minted it.  if we minted it, we then check to see that
+    # the information it contained still authorizes access for the resource it's expected to correspond to.
+    unverified_token = StacksMediaToken.send(:create_from_encrypted_string, encrypted_string)
+    unverified_token.send(:token_valid?, expected_id, expected_file_name, expected_user_ip_addr)
+  rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveSupport::MessageEncryptor::InvalidMessage
+    false
+  end
+
+  def self.create_from_hash(token_hash)
+    new token_hash[:id], token_hash[:file_name], token_hash[:user_ip_addr]
+  end
+  private_class_method :create_from_hash
+
+  # this method can throw ActiveSupport::MessageVerifier::InvalidSignature or
+  # ActiveSupport::MessageEncryptor::InvalidMessage (the former can come from calling
+  # MessageVerifier#verify, the latter from MessageEncryptor#_decrypt, both called by
+  # MessageEncryptor#decrypt_and_verify).
+  def self.create_from_encrypted_string(encrypted_string)
+    token_hash = encryptor.decrypt_and_verify encrypted_string
+    create_from_hash token_hash
+  end
+  private_class_method :create_from_encrypted_string
+
+  def self.encryptor
+    ActiveSupport::MessageEncryptor.new(Rails.application.secrets.secret_key_base)
+  end
+  private_class_method :encryptor
+
+  private
+
+  # the token is valid if
+  #  * it has the values specified by the `expected_` params
+  #  * it hasn't yet expired
+  # NOTE: since this method does an expiry check at the time it's run, its result can
+  # become stale, and should not be cached.
+  def token_valid?(expected_id, expected_file_name, expected_user_ip_addr)
+    # max_token_age returns a duration.  calling `.ago` on it returns a date which we can check against for expiry.
+    id == expected_id && file_name == expected_file_name && user_ip_addr == expected_user_ip_addr &&
+      (timestamp >= self.class.max_token_age.ago)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   constraints file_name: %r{[^/][\w\.-]+} do
     get '/media/:id/:file_name/stream' => 'media#stream', as: :media_stream
     get '/media/auth/:id/:file_name/stream' => 'webauth#login_media_stream', as: :auth_media_stream
+    get '/media/:id/:file_name/verify_token' => 'media#verify_token'
   end
 
   get '/image/iiif' => 'stacks#iiif'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,6 +6,8 @@ purl:
   url: 'https://purl.stanford.edu/'
 
 stream:
+  # max_token_age is specified in seconds
+  max_token_age: 1
   url: http://streaming-server.com:1935/stuff
   # streaming media file extensions we support
   video:

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -68,14 +68,20 @@ describe MediaController, vcr: { record: :new_episodes } do
 
   describe '#stream' do
     let(:streaming_base_url) { Settings.stream.url }
+    let(:token_string) { 'tokenstring' }
+    let(:streaming_url_query_str) { "token_string=#{token_string}" }
     subject { get :stream, id: 'bb582xs1304', file_name: 'bb582xs1304_sl.mp4', format: 'm3u8' }
 
     it 'redirects m3u8 format to streaming server mp4 prefix with playlist.m3u8' do
-      expect(subject).to redirect_to "#{streaming_base_url}/bb/582/xs/1304/mp4:bb582xs1304_sl.mp4/playlist.m3u8"
+      allow(controller).to receive(:media_token).and_return token_string
+      streaming_url_path = '/bb/582/xs/1304/mp4:bb582xs1304_sl.mp4/playlist.m3u8'
+      expect(subject).to redirect_to "#{streaming_base_url}#{streaming_url_path}?#{streaming_url_query_str}"
     end
     it 'redirects mpd format to streaming server mp4 prefix with manifest.mpd' do
+      allow(controller).to receive(:media_token).and_return token_string
       get :stream, id: 'bb582xs1304', file_name: 'bb582xs1304_sl.mp4', format: 'mpd'
-      expect(response).to redirect_to "#{streaming_base_url}/bb/582/xs/1304/mp4:bb582xs1304_sl.mp4/manifest.mpd"
+      streaming_url_path = '/bb/582/xs/1304/mp4:bb582xs1304_sl.mp4/manifest.mpd'
+      expect(response).to redirect_to "#{streaming_base_url}#{streaming_url_path}?#{streaming_url_query_str}"
     end
 
     context 'additional params' do

--- a/spec/models/stacks_media_token_spec.rb
+++ b/spec/models/stacks_media_token_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+describe StacksMediaToken do
+  test_start_time = Time.zone.now
+  let(:id) { 'ab012cd3456' }
+  let(:file_name) { 'def' }
+  let(:user_ip) { '192.168.1.100' }
+  subject { described_class.new(id, file_name, user_ip) }
+
+  describe '#create_from_encrypted_string' do
+    it 'should build an object with the right fields' do
+      encrypted_token_str = subject.to_encrypted_string
+      token_from_encrypted_str = StacksMediaToken.send(:create_from_encrypted_string, encrypted_token_str)
+
+      expect(token_from_encrypted_str.id).to eq id
+      expect(token_from_encrypted_str.file_name).to eq file_name
+      expect(token_from_encrypted_str.user_ip_addr).to eq user_ip
+      expect(token_from_encrypted_str.timestamp).to be >= test_start_time
+      expect(token_from_encrypted_str.timestamp).to be <= Time.zone.now
+    end
+  end
+
+  describe '#token_valid?' do
+    it 'returns true for a valid token' do
+      expect(subject.send(:token_valid?, id, file_name, user_ip)).to eq true
+    end
+
+    it 'returns false if the ids do not match' do
+      expect(subject.send(:token_valid?, 'zy098xv7654', file_name, user_ip)).to eq false
+    end
+
+    it 'returns false if the file names do not match' do
+      expect(subject.send(:token_valid?, id, 'fed', user_ip)).to eq false
+    end
+
+    it 'returns false if the IP addresses do not match' do
+      expect(subject.send(:token_valid?, id, file_name, '192.168.1.101')).to eq false
+    end
+
+    it 'returns false if the token is too old' do
+      expired_timestamp = (StacksMediaToken.max_token_age + 2.seconds).ago
+      allow(subject).to receive(:timestamp).and_return(expired_timestamp)
+      expect(subject.send(:token_valid?, id, file_name, user_ip)).to eq false
+    end
+  end
+
+  describe '#verify_encrypted_token?' do
+    let(:enc_token_str) { subject.to_encrypted_string }
+
+    it 'returns true for a valid token that matches the specified values' do
+      expect(StacksMediaToken.verify_encrypted_token?(enc_token_str, id, file_name, user_ip)).to eq true
+    end
+
+    it 'returns false if the signature is invalid' do
+      invalid_sig_err = ActiveSupport::MessageVerifier::InvalidSignature
+      allow(StacksMediaToken).to receive(:create_from_encrypted_string).with(enc_token_str).and_raise(invalid_sig_err)
+      expect(StacksMediaToken.verify_encrypted_token?(enc_token_str, id, file_name, user_ip)).to eq false
+    end
+
+    it 'returns false if the encrypted message is invalid' do
+      invalid_msg_err = ActiveSupport::MessageEncryptor::InvalidMessage
+      allow(StacksMediaToken).to receive(:create_from_encrypted_string).with(enc_token_str).and_raise(invalid_msg_err)
+      expect(StacksMediaToken.verify_encrypted_token?(enc_token_str, id, file_name, user_ip)).to eq false
+    end
+
+    it 'returns false on a token that has been tampered with' do
+      enc_token_str[0..4] = 'edit' # replace the first 4 characters with something else
+      expect(StacksMediaToken.verify_encrypted_token?(enc_token_str, id, file_name, user_ip)).to eq false
+    end
+
+    it 'returns false if token_valid? returns false' do
+      mock_token = double(StacksMediaToken)
+      allow(StacksMediaToken).to receive(:create_from_encrypted_string).with(enc_token_str).and_return(mock_token)
+      allow(mock_token).to receive(:token_valid?).with(id, file_name, user_ip).and_return(false)
+      expect(StacksMediaToken.verify_encrypted_token?(enc_token_str, id, file_name, user_ip)).to eq false
+    end
+  end
+
+  describe 'field validation' do
+    let(:valid_id1) { 'druid:ab012cd3456' }
+    let(:valid_id2) { 'ab012cd3456' }
+    let(:valid_filename) { 'filename.mp4' }
+    let(:valid_ip) { '192.168.1.100' }
+
+    it 'can create a valid token without raising an error' do
+      expect { StacksMediaToken.new(valid_id1, valid_filename, valid_ip) }.not_to raise_error
+      expect { StacksMediaToken.new(valid_id2, valid_filename, valid_ip) }.not_to raise_error
+    end
+
+    it 'raises an error when creating a token with an empty required field' do
+      expect { StacksMediaToken.new('', valid_filename, valid_ip) }
+        .to raise_error(ActiveModel::StrictValidationFailed, "Id can't be blank")
+      expect { StacksMediaToken.new(valid_id1, '', valid_ip) }
+        .to raise_error(ActiveModel::StrictValidationFailed, "File name can't be blank")
+      expect { StacksMediaToken.new(valid_id1, valid_filename, '') }
+        .to raise_error(ActiveModel::StrictValidationFailed, "User ip addr can't be blank")
+    end
+
+    it 'raises an error when creating a token with a bad id' do
+      expect { StacksMediaToken.new('zab012cd34567', valid_filename, valid_ip) }
+        .to raise_error(ActiveModel::StrictValidationFailed, 'Id is invalid')
+    end
+
+    it 'raises an error when creating a token with a bad IP' do
+      expect { StacksMediaToken.new(valid_id1, valid_filename, '127') }
+        .to raise_error(ActiveModel::StrictValidationFailed, 'User ip addr is invalid')
+      expect { StacksMediaToken.new(valid_id1, valid_filename, '0') }
+        .to raise_error(ActiveModel::StrictValidationFailed, 'User ip addr is invalid')
+      expect { StacksMediaToken.new(valid_id1, valid_filename, '0.0.0.0.0') }
+        .to raise_error(ActiveModel::StrictValidationFailed, 'User ip addr is invalid')
+      expect { StacksMediaToken.new(valid_id1, valid_filename, 'localhost') }
+        .to raise_error(ActiveModel::StrictValidationFailed, 'User ip addr is invalid')
+    end
+  end
+end

--- a/spec/routing/media_routing_spec.rb
+++ b/spec/routing/media_routing_spec.rb
@@ -35,4 +35,9 @@ describe 'Media routes' do
         'webauth#login_media_stream', id: 'id', file_name: 'filename.mp4', format: 'm3u8')
     end
   end
+
+  it 'verify_token' do
+    expect(get: '/media/id/filename.mp4/verify_token?token_string=asdf&user_ip_addr=192.168.1.100').to route_to(
+      'media#verify_token', id: 'id', file_name: 'filename.mp4', token_string: 'asdf', user_ip_addr: '192.168.1.100')
+  end
 end


### PR DESCRIPTION
PR #44 should probably be merged first, then this should get rebased on top of that.

* add a StacksMediaToken class for ephemeral authorization of access by a user to a StacksMediaStream.
* have MediaController#stream include an encrypted token string in its redirects.
* add MediaController#verify_token method (and route to it) to allow other services to verify tokens.

resolve #28