### PR TITLE
media token refactor:  token instead of token_string;  user_ip instead of user_ip_addr

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -31,7 +31,7 @@ class MediaController < ApplicationController
     # get the IP address from a parameter.  the service that's calling verify_token will pass it along,
     # because we care about the IP address that made a request to that service with the token, not the IP
     # address of the service checking the token.
-    if token_valid? allowed_params[:token], id, file_name, allowed_params[:user_ip_addr]
+    if token_valid? allowed_params[:token], id, file_name, allowed_params[:user_ip]
       render text: 'valid token', status: :ok
     else
       render text: 'invalid token', status: :forbidden
@@ -41,7 +41,7 @@ class MediaController < ApplicationController
   private
 
   def allowed_params
-    params.permit(:action, :id, :file_name, :format, :token, :user_ip_addr)
+    params.permit(:action, :id, :file_name, :format, :token, :user_ip)
   end
 
   def rescue_can_can(exception)
@@ -70,8 +70,8 @@ class MediaController < ApplicationController
     @media ||= StacksMediaStream.new(stacks_media_stream_params)
   end
 
-  def token_valid?(token, expected_id, expected_file_name, expected_user_ip_addr)
-    StacksMediaToken.verify_encrypted_token? token, expected_id, expected_file_name, expected_user_ip_addr
+  def token_valid?(token, expected_id, expected_file_name, expected_user_ip)
+    StacksMediaToken.verify_encrypted_token? token, expected_id, expected_file_name, expected_user_ip
   end
 
   def remote_ip_addr

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -19,10 +19,10 @@ class MediaController < ApplicationController
     authorize! :read, @media
     respond_to do |format|
       format.m3u8 do
-        redirect_to "#{@media.to_playlist_url}?token_string=#{media_token}"
+        redirect_to "#{@media.to_playlist_url}?token=#{media_token}"
       end
       format.mpd do
-        redirect_to "#{@media.to_manifest_url}?token_string=#{media_token}"
+        redirect_to "#{@media.to_manifest_url}?token=#{media_token}"
       end
     end
   end
@@ -31,7 +31,7 @@ class MediaController < ApplicationController
     # get the IP address from a parameter.  the service that's calling verify_token will pass it along,
     # because we care about the IP address that made a request to that service with the token, not the IP
     # address of the service checking the token.
-    if token_valid? allowed_params[:token_string], id, file_name, allowed_params[:user_ip_addr]
+    if token_valid? allowed_params[:token], id, file_name, allowed_params[:user_ip_addr]
       render text: 'valid token', status: :ok
     else
       render text: 'invalid token', status: :forbidden
@@ -41,7 +41,7 @@ class MediaController < ApplicationController
   private
 
   def allowed_params
-    params.permit(:action, :id, :file_name, :format, :token_string, :user_ip_addr)
+    params.permit(:action, :id, :file_name, :format, :token, :user_ip_addr)
   end
 
   def rescue_can_can(exception)
@@ -70,8 +70,8 @@ class MediaController < ApplicationController
     @media ||= StacksMediaStream.new(stacks_media_stream_params)
   end
 
-  def token_valid?(token_string, expected_id, expected_file_name, expected_user_ip_addr)
-    StacksMediaToken.verify_encrypted_token? token_string, expected_id, expected_file_name, expected_user_ip_addr
+  def token_valid?(token, expected_id, expected_file_name, expected_user_ip_addr)
+    StacksMediaToken.verify_encrypted_token? token, expected_id, expected_file_name, expected_user_ip_addr
   end
 
   def remote_ip_addr

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -19,19 +19,19 @@ class MediaController < ApplicationController
     authorize! :read, @media
     respond_to do |format|
       format.m3u8 do
-        redirect_to "#{@media.to_playlist_url}?token=#{encrypted_token}"
+        redirect_to "#{@media.to_playlist_url}?stacks_token=#{encrypted_token}"
       end
       format.mpd do
-        redirect_to "#{@media.to_manifest_url}?token=#{encrypted_token}"
+        redirect_to "#{@media.to_manifest_url}?stacks_token=#{encrypted_token}"
       end
     end
   end
 
   def verify_token
-    # get the IP address from a parameter.  the service that's calling verify_token will pass it along,
-    # because we care about the IP address that made a request to that service with the token, not the IP
-    # address of the service checking the token.
-    if token_valid? allowed_params[:token], id, file_name, allowed_params[:user_ip]
+    # the media service calling verify_token provides the end-user IP address,
+    # as we care about the (user) IP address that made a request to the media service with the
+    # stacks_token, not the IP address of the service checking the stacks_token.
+    if token_valid? allowed_params[:stacks_token], id, file_name, allowed_params[:user_ip]
       render text: 'valid token', status: :ok
     else
       render text: 'invalid token', status: :forbidden
@@ -41,7 +41,7 @@ class MediaController < ApplicationController
   private
 
   def allowed_params
-    params.permit(:action, :id, :file_name, :format, :token, :user_ip)
+    params.permit(:action, :id, :file_name, :format, :stacks_token, :user_ip)
   end
 
   def rescue_can_can(exception)

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -68,17 +68,17 @@ describe MediaController, vcr: { record: :new_episodes } do
 
   describe '#stream' do
     let(:streaming_base_url) { Settings.stream.url }
-    let(:token_string) { 'tokenstring' }
-    let(:streaming_url_query_str) { "token_string=#{token_string}" }
+    let(:token) { 'encrypted_token_value' }
+    let(:streaming_url_query_str) { "token=#{token}" }
     subject { get :stream, id: 'bb582xs1304', file_name: 'bb582xs1304_sl.mp4', format: 'm3u8' }
 
     it 'redirects m3u8 format to streaming server mp4 prefix with playlist.m3u8' do
-      allow(controller).to receive(:media_token).and_return token_string
+      allow(controller).to receive(:media_token).and_return token
       streaming_url_path = '/bb/582/xs/1304/mp4:bb582xs1304_sl.mp4/playlist.m3u8'
       expect(subject).to redirect_to "#{streaming_base_url}#{streaming_url_path}?#{streaming_url_query_str}"
     end
     it 'redirects mpd format to streaming server mp4 prefix with manifest.mpd' do
-      allow(controller).to receive(:media_token).and_return token_string
+      allow(controller).to receive(:media_token).and_return token
       get :stream, id: 'bb582xs1304', file_name: 'bb582xs1304_sl.mp4', format: 'mpd'
       streaming_url_path = '/bb/582/xs/1304/mp4:bb582xs1304_sl.mp4/manifest.mpd'
       expect(response).to redirect_to "#{streaming_base_url}#{streaming_url_path}?#{streaming_url_query_str}"
@@ -127,19 +127,19 @@ describe MediaController, vcr: { record: :new_episodes } do
     let(:file_name) { 'interesting_video.mp4' }
     let(:ip_addr) { '192.168.1.100' }
     let(:token) { StacksMediaToken.new(id, file_name, ip_addr) }
-    let(:token_string) { token.to_encrypted_string }
+    let(:encrypted_token) { token.to_encrypted_string }
 
     context 'mock #token_valid?' do
       it 'verifies a token when token_valid? returns true' do
-        expect(controller).to receive(:token_valid?).with(token_string, id, file_name, ip_addr).and_return true
-        get :verify_token, token_string: token_string, id: id, file_name: file_name, user_ip_addr: ip_addr
+        expect(controller).to receive(:token_valid?).with(encrypted_token, id, file_name, ip_addr).and_return true
+        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip_addr: ip_addr
         expect(response.body).to eq 'valid token'
         expect(response.status).to eq 200
       end
 
       it 'rejects a token when token_valid? returns false' do
-        expect(controller).to receive(:token_valid?).with(token_string, id, file_name, ip_addr).and_return false
-        get :verify_token, token_string: token_string, id: id, file_name: file_name, user_ip_addr: ip_addr
+        expect(controller).to receive(:token_valid?).with(encrypted_token, id, file_name, ip_addr).and_return false
+        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip_addr: ip_addr
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
@@ -149,31 +149,31 @@ describe MediaController, vcr: { record: :new_episodes } do
       # these tests are a bit more integration-ish, since they actually end up calling
       # StacksMediaToken.verify_encrypted_token? instead of mocking the call to MediaController#token_valid?
       it 'verifies a valid token' do
-        get :verify_token, token_string: token_string, id: id, file_name: file_name, user_ip_addr: ip_addr
+        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip_addr: ip_addr
         expect(response.body).to eq 'valid token'
         expect(response.status).to eq 200
       end
 
       it 'rejects a token with a corrupted encrypted token string' do
-        get :verify_token, token_string: "#{token_string}aaaa", id: id, file_name: file_name, user_ip_addr: ip_addr
+        get :verify_token, token: "#{encrypted_token}aaaa", id: id, file_name: file_name, user_ip_addr: ip_addr
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
 
       it 'rejects a token for the wrong id' do
-        get :verify_token, token_string: token_string, id: 'zy098xv7654', file_name: file_name, user_ip_addr: ip_addr
+        get :verify_token, token: encrypted_token, id: 'zy098xv7654', file_name: file_name, user_ip_addr: ip_addr
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
 
       it 'rejects a token for the wrong file name' do
-        get :verify_token, token_string: token_string, id: id, file_name: 'some_other_file.mp3', user_ip_addr: ip_addr
+        get :verify_token, token: encrypted_token, id: id, file_name: 'some_other_file.mp3', user_ip_addr: ip_addr
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
 
       it 'rejects a token from the wrong IP address' do
-        get :verify_token, token_string: token_string, id: id, file_name: file_name, user_ip_addr: '192.168.1.101'
+        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip_addr: '192.168.1.101'
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
@@ -181,7 +181,7 @@ describe MediaController, vcr: { record: :new_episodes } do
       it 'rejects a token that is too old' do
         expired_timestamp = (StacksMediaToken.max_token_age + 2.seconds).ago
         expect(token).to receive(:timestamp).and_return(expired_timestamp)
-        get :verify_token, token_string: token_string, id: id, file_name: file_name, user_ip_addr: '192.168.1.101'
+        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip_addr: '192.168.1.101'
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
@@ -191,8 +191,8 @@ describe MediaController, vcr: { record: :new_episodes } do
   describe '#token_valid?' do
     it 'should call through to StacksMediaToken.verify_encrypted_token? and return the result' do
       expect(StacksMediaToken).to receive(:verify_encrypted_token?)
-        .with('token_string', 'id', 'file_name', 'ip_addr').and_return(true)
-      expect(controller.send(:token_valid?, 'token_string', 'id', 'file_name', 'ip_addr')).to eq true
+        .with('token', 'id', 'file_name', 'ip_addr').and_return(true)
+      expect(controller.send(:token_valid?, 'token', 'id', 'file_name', 'ip_addr')).to eq true
     end
   end
 end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -69,7 +69,7 @@ describe MediaController, vcr: { record: :new_episodes } do
   describe '#stream' do
     let(:streaming_base_url) { Settings.stream.url }
     let(:encrypted_token) { 'encrypted_token_value' }
-    let(:streaming_url_query_str) { "token=#{encrypted_token}" }
+    let(:streaming_url_query_str) { "stacks_token=#{encrypted_token}" }
     subject { get :stream, id: 'bb582xs1304', file_name: 'bb582xs1304_sl.mp4', format: 'm3u8' }
 
     it 'redirects m3u8 format to streaming server mp4 prefix with playlist.m3u8' do
@@ -132,14 +132,14 @@ describe MediaController, vcr: { record: :new_episodes } do
     context 'mock #token_valid?' do
       it 'verifies a token when token_valid? returns true' do
         expect(controller).to receive(:token_valid?).with(encrypted_token, id, file_name, ip_addr).and_return true
-        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip: ip_addr
+        get :verify_token, stacks_token: encrypted_token, id: id, file_name: file_name, user_ip: ip_addr
         expect(response.body).to eq 'valid token'
         expect(response.status).to eq 200
       end
 
       it 'rejects a token when token_valid? returns false' do
         expect(controller).to receive(:token_valid?).with(encrypted_token, id, file_name, ip_addr).and_return false
-        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip: ip_addr
+        get :verify_token, stacks_token: encrypted_token, id: id, file_name: file_name, user_ip: ip_addr
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
@@ -149,31 +149,31 @@ describe MediaController, vcr: { record: :new_episodes } do
       # these tests are a bit more integration-ish, since they actually end up calling
       # StacksMediaToken.verify_encrypted_token? instead of mocking the call to MediaController#token_valid?
       it 'verifies a valid token' do
-        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip: ip_addr
+        get :verify_token, stacks_token: encrypted_token, id: id, file_name: file_name, user_ip: ip_addr
         expect(response.body).to eq 'valid token'
         expect(response.status).to eq 200
       end
 
       it 'rejects a token with a corrupted encrypted token string' do
-        get :verify_token, token: "#{encrypted_token}aaaa", id: id, file_name: file_name, user_ip: ip_addr
+        get :verify_token, stacks_token: "#{encrypted_token}aaaa", id: id, file_name: file_name, user_ip: ip_addr
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
 
       it 'rejects a token for the wrong id' do
-        get :verify_token, token: encrypted_token, id: 'zy098xv7654', file_name: file_name, user_ip: ip_addr
+        get :verify_token, stacks_token: encrypted_token, id: 'zy098xv7654', file_name: file_name, user_ip: ip_addr
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
 
       it 'rejects a token for the wrong file name' do
-        get :verify_token, token: encrypted_token, id: id, file_name: 'some_other_file.mp3', user_ip: ip_addr
+        get :verify_token, stacks_token: encrypted_token, id: id, file_name: 'some_other_file.mp3', user_ip: ip_addr
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
 
       it 'rejects a token from the wrong IP address' do
-        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip: '192.168.1.101'
+        get :verify_token, stacks_token: encrypted_token, id: id, file_name: file_name, user_ip: '192.168.1.101'
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
@@ -181,7 +181,7 @@ describe MediaController, vcr: { record: :new_episodes } do
       it 'rejects a token that is too old' do
         expired_timestamp = (StacksMediaToken.max_token_age + 2.seconds).ago
         expect(token).to receive(:timestamp).and_return(expired_timestamp)
-        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip: '192.168.1.101'
+        get :verify_token, stacks_token: encrypted_token, id: id, file_name: file_name, user_ip: '192.168.1.101'
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
@@ -191,8 +191,8 @@ describe MediaController, vcr: { record: :new_episodes } do
   describe '#token_valid?' do
     it 'should call through to StacksMediaToken.verify_encrypted_token? and return the result' do
       expect(StacksMediaToken).to receive(:verify_encrypted_token?)
-        .with('token', 'id', 'file_name', 'ip_addr').and_return(true)
-      expect(controller.send(:token_valid?, 'token', 'id', 'file_name', 'ip_addr')).to eq true
+        .with('stacks_token', 'id', 'file_name', 'ip_addr').and_return(true)
+      expect(controller.send(:token_valid?, 'stacks_token', 'id', 'file_name', 'ip_addr')).to eq true
     end
   end
 end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -73,12 +73,12 @@ describe MediaController, vcr: { record: :new_episodes } do
     subject { get :stream, id: 'bb582xs1304', file_name: 'bb582xs1304_sl.mp4', format: 'm3u8' }
 
     it 'redirects m3u8 format to streaming server mp4 prefix with playlist.m3u8' do
-      allow(controller).to receive(:media_token).and_return encrypted_token
+      allow(controller).to receive(:encrypted_token).and_return encrypted_token
       streaming_url_path = '/bb/582/xs/1304/mp4:bb582xs1304_sl.mp4/playlist.m3u8'
       expect(subject).to redirect_to "#{streaming_base_url}#{streaming_url_path}?#{streaming_url_query_str}"
     end
     it 'redirects mpd format to streaming server mp4 prefix with manifest.mpd' do
-      allow(controller).to receive(:media_token).and_return encrypted_token
+      allow(controller).to receive(:encrypted_token).and_return encrypted_token
       get :stream, id: 'bb582xs1304', file_name: 'bb582xs1304_sl.mp4', format: 'mpd'
       streaming_url_path = '/bb/582/xs/1304/mp4:bb582xs1304_sl.mp4/manifest.mpd'
       expect(response).to redirect_to "#{streaming_base_url}#{streaming_url_path}?#{streaming_url_query_str}"

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -132,14 +132,14 @@ describe MediaController, vcr: { record: :new_episodes } do
     context 'mock #token_valid?' do
       it 'verifies a token when token_valid? returns true' do
         expect(controller).to receive(:token_valid?).with(encrypted_token, id, file_name, ip_addr).and_return true
-        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip_addr: ip_addr
+        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip: ip_addr
         expect(response.body).to eq 'valid token'
         expect(response.status).to eq 200
       end
 
       it 'rejects a token when token_valid? returns false' do
         expect(controller).to receive(:token_valid?).with(encrypted_token, id, file_name, ip_addr).and_return false
-        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip_addr: ip_addr
+        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip: ip_addr
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
@@ -149,31 +149,31 @@ describe MediaController, vcr: { record: :new_episodes } do
       # these tests are a bit more integration-ish, since they actually end up calling
       # StacksMediaToken.verify_encrypted_token? instead of mocking the call to MediaController#token_valid?
       it 'verifies a valid token' do
-        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip_addr: ip_addr
+        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip: ip_addr
         expect(response.body).to eq 'valid token'
         expect(response.status).to eq 200
       end
 
       it 'rejects a token with a corrupted encrypted token string' do
-        get :verify_token, token: "#{encrypted_token}aaaa", id: id, file_name: file_name, user_ip_addr: ip_addr
+        get :verify_token, token: "#{encrypted_token}aaaa", id: id, file_name: file_name, user_ip: ip_addr
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
 
       it 'rejects a token for the wrong id' do
-        get :verify_token, token: encrypted_token, id: 'zy098xv7654', file_name: file_name, user_ip_addr: ip_addr
+        get :verify_token, token: encrypted_token, id: 'zy098xv7654', file_name: file_name, user_ip: ip_addr
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
 
       it 'rejects a token for the wrong file name' do
-        get :verify_token, token: encrypted_token, id: id, file_name: 'some_other_file.mp3', user_ip_addr: ip_addr
+        get :verify_token, token: encrypted_token, id: id, file_name: 'some_other_file.mp3', user_ip: ip_addr
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
 
       it 'rejects a token from the wrong IP address' do
-        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip_addr: '192.168.1.101'
+        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip: '192.168.1.101'
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end
@@ -181,7 +181,7 @@ describe MediaController, vcr: { record: :new_episodes } do
       it 'rejects a token that is too old' do
         expired_timestamp = (StacksMediaToken.max_token_age + 2.seconds).ago
         expect(token).to receive(:timestamp).and_return(expired_timestamp)
-        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip_addr: '192.168.1.101'
+        get :verify_token, token: encrypted_token, id: id, file_name: file_name, user_ip: '192.168.1.101'
         expect(response.body).to eq 'invalid token'
         expect(response.status).to eq 403
       end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -68,17 +68,17 @@ describe MediaController, vcr: { record: :new_episodes } do
 
   describe '#stream' do
     let(:streaming_base_url) { Settings.stream.url }
-    let(:token) { 'encrypted_token_value' }
-    let(:streaming_url_query_str) { "token=#{token}" }
+    let(:encrypted_token) { 'encrypted_token_value' }
+    let(:streaming_url_query_str) { "token=#{encrypted_token}" }
     subject { get :stream, id: 'bb582xs1304', file_name: 'bb582xs1304_sl.mp4', format: 'm3u8' }
 
     it 'redirects m3u8 format to streaming server mp4 prefix with playlist.m3u8' do
-      allow(controller).to receive(:media_token).and_return token
+      allow(controller).to receive(:media_token).and_return encrypted_token
       streaming_url_path = '/bb/582/xs/1304/mp4:bb582xs1304_sl.mp4/playlist.m3u8'
       expect(subject).to redirect_to "#{streaming_base_url}#{streaming_url_path}?#{streaming_url_query_str}"
     end
     it 'redirects mpd format to streaming server mp4 prefix with manifest.mpd' do
-      allow(controller).to receive(:media_token).and_return token
+      allow(controller).to receive(:media_token).and_return encrypted_token
       get :stream, id: 'bb582xs1304', file_name: 'bb582xs1304_sl.mp4', format: 'mpd'
       streaming_url_path = '/bb/582/xs/1304/mp4:bb582xs1304_sl.mp4/manifest.mpd'
       expect(response).to redirect_to "#{streaming_base_url}#{streaming_url_path}?#{streaming_url_query_str}"

--- a/spec/models/stacks_media_token_spec.rb
+++ b/spec/models/stacks_media_token_spec.rb
@@ -14,7 +14,7 @@ describe StacksMediaToken do
 
       expect(token_from_encrypted_str.id).to eq id
       expect(token_from_encrypted_str.file_name).to eq file_name
-      expect(token_from_encrypted_str.user_ip_addr).to eq user_ip
+      expect(token_from_encrypted_str.user_ip).to eq user_ip
       expect(token_from_encrypted_str.timestamp).to be >= test_start_time
       expect(token_from_encrypted_str.timestamp).to be <= Time.zone.now
     end
@@ -93,7 +93,7 @@ describe StacksMediaToken do
       expect { StacksMediaToken.new(valid_id1, '', valid_ip) }
         .to raise_error(ActiveModel::StrictValidationFailed, "File name can't be blank")
       expect { StacksMediaToken.new(valid_id1, valid_filename, '') }
-        .to raise_error(ActiveModel::StrictValidationFailed, "User ip addr can't be blank")
+        .to raise_error(ActiveModel::StrictValidationFailed, "User ip can't be blank")
     end
 
     it 'raises an error when creating a token with a bad id' do
@@ -103,13 +103,13 @@ describe StacksMediaToken do
 
     it 'raises an error when creating a token with a bad IP' do
       expect { StacksMediaToken.new(valid_id1, valid_filename, '127') }
-        .to raise_error(ActiveModel::StrictValidationFailed, 'User ip addr is invalid')
+        .to raise_error(ActiveModel::StrictValidationFailed, 'User ip is invalid')
       expect { StacksMediaToken.new(valid_id1, valid_filename, '0') }
-        .to raise_error(ActiveModel::StrictValidationFailed, 'User ip addr is invalid')
+        .to raise_error(ActiveModel::StrictValidationFailed, 'User ip is invalid')
       expect { StacksMediaToken.new(valid_id1, valid_filename, '0.0.0.0.0') }
-        .to raise_error(ActiveModel::StrictValidationFailed, 'User ip addr is invalid')
+        .to raise_error(ActiveModel::StrictValidationFailed, 'User ip is invalid')
       expect { StacksMediaToken.new(valid_id1, valid_filename, 'localhost') }
-        .to raise_error(ActiveModel::StrictValidationFailed, 'User ip addr is invalid')
+        .to raise_error(ActiveModel::StrictValidationFailed, 'User ip is invalid')
     end
   end
 end

--- a/spec/routing/media_routing_spec.rb
+++ b/spec/routing/media_routing_spec.rb
@@ -37,7 +37,7 @@ describe 'Media routes' do
   end
 
   it 'verify_token' do
-    expect(get: '/media/id/filename.mp4/verify_token?token=asdf&user_ip=192.168.1.100').to route_to(
-      'media#verify_token', id: 'id', file_name: 'filename.mp4', token: 'asdf', user_ip: '192.168.1.100')
+    expect(get: '/media/id/filename.mp4/verify_token?stacks_token=asdf&user_ip=192.168.1.100').to route_to(
+      'media#verify_token', id: 'id', file_name: 'filename.mp4', stacks_token: 'asdf', user_ip: '192.168.1.100')
   end
 end

--- a/spec/routing/media_routing_spec.rb
+++ b/spec/routing/media_routing_spec.rb
@@ -37,7 +37,7 @@ describe 'Media routes' do
   end
 
   it 'verify_token' do
-    expect(get: '/media/id/filename.mp4/verify_token?token_string=asdf&user_ip_addr=192.168.1.100').to route_to(
-      'media#verify_token', id: 'id', file_name: 'filename.mp4', token_string: 'asdf', user_ip_addr: '192.168.1.100')
+    expect(get: '/media/id/filename.mp4/verify_token?token=asdf&user_ip_addr=192.168.1.100').to route_to(
+      'media#verify_token', id: 'id', file_name: 'filename.mp4', token: 'asdf', user_ip_addr: '192.168.1.100')
   end
 end

--- a/spec/routing/media_routing_spec.rb
+++ b/spec/routing/media_routing_spec.rb
@@ -37,7 +37,7 @@ describe 'Media routes' do
   end
 
   it 'verify_token' do
-    expect(get: '/media/id/filename.mp4/verify_token?token=asdf&user_ip_addr=192.168.1.100').to route_to(
-      'media#verify_token', id: 'id', file_name: 'filename.mp4', token: 'asdf', user_ip_addr: '192.168.1.100')
+    expect(get: '/media/id/filename.mp4/verify_token?token=asdf&user_ip=192.168.1.100').to route_to(
+      'media#verify_token', id: 'id', file_name: 'filename.mp4', token: 'asdf', user_ip: '192.168.1.100')
   end
 end


### PR DESCRIPTION
I think "token" is good enough as a param name, but if we *must* have something more than that, I think "stacks_token" is better than "token_string".

Also not sure of underscores vs camel case in HTTP GET params.  Which is another reason why shorter feels better to me.

I also did a separate commit shortening user_ip_addr  to user_ip

@jmartin-sul