### PR TITLE
cap deploy prompts for branch and does info level logging

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,7 +5,7 @@ set :application, 'digital_stacks'
 set :repo_url, 'https://github.com/sul-dlss/digital_stacks_rails.git'
 
 # Default branch is :master
-# ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
+ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
 
 # Default deploy_to directory is /var/www/my_app
 set :deploy_to, '/opt/app/stacks/stacks'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -17,7 +17,7 @@ set :deploy_to, '/opt/app/stacks/stacks'
 # set :format, :pretty
 
 # Default value for :log_level is :debug
-# set :log_level, :debug
+set :log_level, :info
 
 # Default value for :pty is false
 # set :pty, true

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -2,5 +2,3 @@ server 'sul-stacks-test.stanford.edu', user: 'stacks', roles: %w{web db app}
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, "production"
-set :branch, ENV["BRANCH"] || "master"
-


### PR DESCRIPTION
We need to be able to deploy to sul-stacks-test from a branch, and the debug logging was creating a lot of confusing noise in the deploy.

It looks like the old way to deploy a branch to "test" was to use an ENV variable - that isn't a pattern I've come across before ...

I am also keenly aware that our VM is called sul-stacks-test, but the cap deploy is "staging" -- shouldn't it be "test" or "stage" ?  Do we have standard practice here?  Is it not worth changing because the VM is "test" ?