### PR TITLE
handle special chars in download and stream URLs, add tests for special char handling in URLs in general

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ config/environments/*.local.yml
 !/log/.keep
 /tmp
 /coverage
+
+.pry_history

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,13 +5,16 @@ Rails.application.routes.draw do
     get '/file/auth/:id/:file_name' => 'webauth#login_file', as: :auth_file
   end
 
-  constraints file_name: %r{[^/][\w-]+} do
+  # download file_name must NOT include format extension (e.g.  .mp4)
+  # so insist on . being URL encoded (see media routing specs)
+  constraints file_name: %r{[^/\.]+} do
     get '/media/:id/:file_name' => 'media#download', as: :media
     get '/media/auth/:id/:file_name' => 'webauth#login_media_download', as: :auth_media_download
   end
 
   # stream file_name must include format extension, eg .../oo000oo0000.mp4/stream
-  constraints file_name: %r{[^/][\w\.-]+} do
+  #  other dots do not need to be URL encoded (see media routing specs)
+  constraints file_name: %r{[^/]+\.\w+} do
     get '/media/:id/:file_name/stream' => 'media#stream', as: :media_stream
     get '/media/auth/:id/:file_name/stream' => 'webauth#login_media_stream', as: :auth_media_stream
     get '/media/:id/:file_name/verify_token' => 'media#verify_token'

--- a/spec/routing/file_routing_spec.rb
+++ b/spec/routing/file_routing_spec.rb
@@ -5,6 +5,49 @@ describe 'file routes' do
     expect(get: '/file/abc/def.pdf').to route_to('file#show', id: 'abc', file_name: 'def.pdf')
   end
 
+  context '#show (download): filename with' do
+    it 'chars not requiring URI escaping' do
+      filename = "(no_escape_needed):;=&$*.-_+!,~'.ext"
+      expect(get: "/file/oo000oo0000/#{filename}").to route_to(
+        'file#show', id: 'oo000oo0000', file_name: filename)
+    end
+
+    it 'some chars requiring URI escaping' do
+      filename = 'escape_needed {} @#^ %|"`.ext'
+      expect(get: "/file/oo000oo0000/#{URI.escape(filename)}").to route_to(
+        'file#show', id: 'oo000oo0000', file_name: filename)
+    end
+
+    it 'square brackets must be url escaped' do
+      filename = 'foo[brackets].bar.pdf'
+      escaped_filename = 'foo%5Bbrackets%5D.bar.pdf' # URI.escape doesn't do square brackets
+      expect(get: "/file/oo000oo0000/#{escaped_filename}").to route_to(
+        'file#show', id: 'oo000oo0000', file_name: filename)
+    end
+
+    it 'question mark must be url escaped' do
+      filename = 'foo?.pdf'
+      escaped_filename = 'foo%3F.pdf' # URI.escape doesn't do question mark
+      expect(get: "/file/oo000oo0000/#{escaped_filename}").to route_to(
+        'file#show', id: 'oo000oo0000', file_name: filename)
+    end
+
+    it 'ü must be url escaped' do
+      skip('problem writing test:  ü decodes to \xC3\xBC')
+      filename = "fü.pdf"
+      escaped_filename = URI.escape(filename) # becomes %C3%BC
+      expect(get: "/file/oo000oo0000/#{escaped_filename}").to route_to(
+        'file#show', id: 'oo000oo0000', file_name: filename)
+    end
+
+    it '%20 in actual name (from ck155rf0207)' do
+      skip('problem writing test:  %20 becomes space, over-aggressive param decoding?')
+      filename = 'ARSCJ%202008.foo.bar.pdf'
+      expect(get: "/file/oo000oo0000/#{URI.escape(filename)}").to route_to(
+        'file#show', id: 'oo000oo0000', file_name: filename)
+    end
+  end
+
   describe 'authorization' do
     it 'routes to webauth#login_file' do
       expect(get: '/file/auth/abc/def.pdf').to route_to('webauth#login_file', id: 'abc', file_name: 'def.pdf')


### PR DESCRIPTION
this builds on the work @ndushay started in 49-tests-for-special-chars-in-url. 

Note that it may not be perfectly what we want at this time, but it should be LESS BROKEN that our original filenames for media routes.

 it:
* alters a couple file name parameter constraints to allow for special char handling in media streaming and download routes.
* adds a note about a limitation on usable file names for the download routes.
* does some rubocop mandated style cleanup on the tests naomi already added for special character handling in general across media, file, and iiif routing specs.
* refines some skip messages on some of the tests naomi added.

connects to #49 