### PR TITLE
don't grant IIIF bearer tokens to anonymous users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,7 +62,8 @@ class ApplicationController < ActionController::Base
   end
 
   def anonymous_locatable_user
-    User.new(ip_address: request.remote_ip)
+    User.new(ip_address: request.remote_ip,
+             anonymous_locatable_user: true)
   end
 
   def rescue_can_can(exception)

--- a/app/controllers/iiif_token_controller.rb
+++ b/app/controllers/iiif_token_controller.rb
@@ -1,7 +1,7 @@
 # API to create IIIF Authentication access tokens
 class IiifTokenController < ApplicationController
   def create
-    token = mint_bearer_token if current_user
+    token = mint_bearer_token unless current_user.anonymous_locatable_user?
 
     write_bearer_token_cookie(token) if token
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,10 +3,14 @@
 class User
   include ActiveModel::Model
 
-  attr_accessor :id, :webauth_user, :app_user, :token_user, :ldap_groups, :ip_address
+  attr_accessor :id, :webauth_user, :anonymous_locatable_user, :app_user, :token_user, :ldap_groups, :ip_address
 
   def webauth_user?
     webauth_user
+  end
+
+  def anonymous_locatable_user?
+    anonymous_locatable_user
   end
 
   def stanford?

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -42,5 +42,11 @@ describe ApplicationController do
         expect(subject).to be_a_webauth_user
       end
     end
+
+    context 'with no other credentials' do
+      it 'is an anonymous locatable user' do
+        expect(subject).to be_an_anonymous_locatable_user
+      end
+    end
   end
 end

--- a/spec/controllers/iiif_token_controller_spec.rb
+++ b/spec/controllers/iiif_token_controller_spec.rb
@@ -6,7 +6,7 @@ describe IiifTokenController do
       get :create, format: :js
     end
 
-    let(:user) { nil }
+    let(:user) { User.new(anonymous_locatable_user: true) }
 
     before do
       allow(controller).to receive(:current_user).and_return(user)
@@ -35,7 +35,7 @@ describe IiifTokenController do
       end
     end
 
-    context 'without a user' do
+    context 'with an anonymous user' do
       it 'returns the error response' do
         expect(subject.status).to eq 401
 


### PR DESCRIPTION
before the anonymous locatable user type was added, anonymous users weren't granted IIIF bearer tokens.  the addition of anonymous users introduced a regression:  previously, anonymous users would result in `nil` when `current_user` got called, but now `current_user` will never return nil, and so a caller would always get a token.

this PR fixes the regression by adding a flag indicating when a user is an anonymous locatable user, and checking that flag before the IIIF bearer token is issued.  it also adds a test for the new flag and fixes an old test so that it would've failed and caught the regression.

deployed to stacks-test.

paired w/ @jkeck

fixes sul-dlss/sul-embed#591
connect to sul-dlss/sul-embed#591