### PR TITLE
is_it_working: make djatoka_url a non_crucial check

### DIFF
--- a/config/initializers/is_it_working.rb
+++ b/config/initializers/is_it_working.rb
@@ -1,7 +1,11 @@
 Rails.configuration.middleware.use(IsItWorking::Handler) do |h|
   h.check :directory, path: File.join(Settings.stacks.storage_root, 'bb')
   h.check :url, get: Settings.purl.url
-  h.check :url, get: Settings.stacks.djatoka_url + '?rft_id=/&svc_id=info:lanl-repo/svc/ping&url_ver=Z39.88-2004'
+
+  h.check :non_crucial do |status|
+    djatoka_url_to_check = Settings.stacks.djatoka_url + '?rft_id=/&svc_id=info:lanl-repo/svc/ping&url_ver=Z39.88-2004'
+    non_crucial_url_check(djatoka_url_to_check, status, 'For image content in image viewer')
+  end
 
   h.check :non_crucial do |status|
     non_crucial_url_check(Settings.stream.url, status, 'For streaming content in media viewer')


### PR DESCRIPTION
per discussion in standup this morning, stacks isn't down if the image server is down -- only images in the stacks are down (not media, not files, ...)