### PR TITLE
Hardcode response format in auth_check, to please IE/Edge on Windows 10.

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -22,9 +22,9 @@ class MediaController < ApplicationController
 
   # jsonp response
   def auth_check
-    respond_to do |format|
-      format.js { render json: hash_for_auth_check, callback: allowed_params[:callback] }
-    end
+    # IE 11 and Edge on Windows 10 doesn't request the correct format. So just hardcode
+    # JSON as the return format since that's what we always do.
+    render json: hash_for_auth_check, callback: allowed_params[:callback]
   end
 
   private


### PR DESCRIPTION
For Windows 10, Internet Explorer 11 and Edge seem to request the wrong content type when the jQuery Ajax request to the auth_check endpoint is issued (this happens when Sul-Embed tries to play a video or audio file). Since we actually only ever return JSON from auth_check, this PR simply hardcodes the response format without testing the actual format requested. This is an easy and seemingly foolproof way to please all browsers. This is the stacks-side of the fix for sul-dlss/media#122.