### PR TITLE
stacks_file: remove valid? method as it made no sense

### DIFF
--- a/app/models/stacks_file.rb
+++ b/app/models/stacks_file.rb
@@ -15,12 +15,6 @@ class StacksFile
     path && File.exist?(path)
   end
 
-  def valid?
-    # FIXME: image_exist? is defined in app/models/concerns/djatoka_adapter.rb,
-    #  which is included in StacksImage, but is probably undefined here
-    image_exist?
-  end
-
   def mtime
     @mtime ||= File.mtime(path) if file_exist?
   end


### PR DESCRIPTION
I suspect this method was vestigial from some copy-paste that went bad, or something.

resolves #32