### PR TITLE
okcomputer: include line breaks in html

### DIFF
--- a/config/locales/okcomputer_en.yml
+++ b/config/locales/okcomputer_en.yml
@@ -1,0 +1,8 @@
+# this is needed so html okcomputer formatting (mounted at status/all) is somewhat readable
+#  if https://github.com/sportngin/okcomputer/pull/117  is merged, the <br/> should be
+#  moved to the ends of the lines.
+en:
+  okcomputer:
+    check:
+      passed: "<br/> %{registrant_name}: PASSED %{message} (%{time})"
+      failed: "<br/> %{registrant_name}: FAILED %{message} (%{time})"


### PR DESCRIPTION
#### `status/all` before:

![status before](https://cloud.githubusercontent.com/assets/96775/18856520/2ba55d6e-8410-11e6-951b-5cb99ead702a.png)

#### `status/all` after:

![status after](https://cloud.githubusercontent.com/assets/96775/18856519/2ba18c34-8410-11e6-9e00-366f2e3fea3c.png)

